### PR TITLE
Fix membrane code and invariants

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function isPrimitive(obj) {
  */
 function createWrapFn(originalsToProxies, proxiesToOriginals) {
     /**
-     * @param {proxy} proxy
+     * @param {any} proxy
      */
     function unwrap(proxy) {
         if (proxiesToOriginals.has(proxy)) {
@@ -123,7 +123,7 @@ function createWrapFn(originalsToProxies, proxiesToOriginals) {
                 value = unwrap(value);
                 receiver = unwrap(receiver);
 
-                return Reflect.set(target, p, value, receiver);
+                return Reflect.set(original, p, value, receiver);
             },
 
             // following methods also should be implemented,

--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ function createWrapFn(originalsToProxies, proxiesToOriginals) {
         //       note that we don't use `original` here as proxy target
         //                     ↓↓↓↓↓↓↓↓↓↓↓↓↓↓
         // TODO
+        // const proxy = newProxy(privateHandler, {
         const proxy = new Proxy(privateHandler, {
             apply(target, thisArg, argArray) {
                 thisArg = unwrap(thisArg);
@@ -123,6 +124,8 @@ function createWrapFn(originalsToProxies, proxiesToOriginals) {
                 value = unwrap(value);
                 receiver = unwrap(receiver);
 
+                // but we use `original` here instead of `target`
+                //                 ↓↓↓↓↓↓↓↓
                 return Reflect.set(original, p, value, receiver);
             },
 

--- a/index.js
+++ b/index.js
@@ -15,9 +15,18 @@ function isPrimitive(obj) {
 /**
  * @param {WeakMap<object, any>} originalsToProxies
  * @param {WeakMap<object, any>} proxiesToOriginals
- * @param {(proxy: any) => any} unwrapFn
  */
-function createWrapFn(originalsToProxies, proxiesToOriginals, unwrapFn) {
+function createWrapFn(originalsToProxies, proxiesToOriginals) {
+    /**
+     * @param {proxy} proxy
+     */
+    function unwrap(proxy) {
+        if (proxiesToOriginals.has(proxy)) {
+            return proxiesToOriginals.get(proxy);
+        }
+        return wrap(proxy);
+    }
+
     /**
      * `privateHandlers` are special objects dedicated to keep invariants built
      * on top of exposing private symbols via public API
@@ -38,12 +47,15 @@ function createWrapFn(originalsToProxies, proxiesToOriginals, unwrapFn) {
      */
     function handlePrivate(handler, privateSymbol) {
         const original = privateHandlersOriginals.get(handler);
+        if (handler.hasOwnProperty(privateSymbol)) {
+            return;
+        }
         Object.defineProperty(handler, privateSymbol, {
             get() {
                 return wrap(original[privateSymbol]);
             },
             set(v) {
-                original[privateSymbol] = unwrapFn(v);
+                original[privateSymbol] = unwrap(v);
             }
         });
     }
@@ -61,18 +73,21 @@ function createWrapFn(originalsToProxies, proxiesToOriginals, unwrapFn) {
         const privateHandler = typeof original === 'function'
             ? () => { }
             : {};
-        privateHandlersOriginals.set(privateHandler, original);
-        allHandlers.add(privateHandler);
+
+        // TODO
+        // privateHandlersOriginals.set(privateHandler, original);
+        // allHandlers.add(privateHandler);
 
         // we use `newProxy` instead of `new Proxy` to emulate behavior of `Symbol.private`
         //       note that we don't use `original` here as proxy target
         //                     ↓↓↓↓↓↓↓↓↓↓↓↓↓↓
-        const proxy = newProxy(privateHandler, {
+        // TODO
+        const proxy = new Proxy(privateHandler, {
             apply(target, thisArg, argArray) {
-                thisArg = unwrapFn(thisArg);
+                thisArg = unwrap(thisArg);
                 for (let i = 0; i < argArray.length; i++) {
                     if (!isPrimitive(argArray[i])) {
-                        argArray[i] = unwrapFn(argArray[i]);
+                        argArray[i] = unwrap(argArray[i]);
                     }
                 }
 
@@ -83,13 +98,14 @@ function createWrapFn(originalsToProxies, proxiesToOriginals, unwrapFn) {
                 // in case when private symbols is exposed via some part of public API
                 // we have to add such symbol to all possible targets where it could appear
                 if (typeof retval === 'symbol' /* && retval.private */) {
-                    allHandlers.forEach(handler => handlePrivate(handler, retval));
+                    // TODO
+                    // allHandlers.forEach(handler => handlePrivate(handler, retval));
                 }
 
-                return wrap(retval);
+                return unwrap(retval);
             },
             get(target, p, receiver) {
-                receiver = unwrapFn(receiver);
+                receiver = unwrap(receiver);
                 //       but we use `original` here instead of `target`
                 //                         ↓↓↓↓↓↓↓↓
                 const retval = Reflect.get(original, p, receiver);
@@ -97,11 +113,19 @@ function createWrapFn(originalsToProxies, proxiesToOriginals, unwrapFn) {
                 // in case when private symbols is exposed via some part of public API
                 // we have to add such symbol to all possible targets where it could appear
                 if (typeof retval === 'symbol' /* && retval.private */) {
-                    allHandlers.forEach(handler => handlePrivate(handler, retval));
+                    // TODO
+                    // allHandlers.forEach(handler => handlePrivate(handler, retval));
                 }
 
-                return wrap(retval);
+                return unwrap(retval);
             },
+            set(target, p, value, receiver) {
+                value = unwrap(value);
+                receiver = unwrap(receiver);
+
+                return Reflect.set(target, p, value, receiver);
+            },
+
             // following methods also should be implemented,
             // but it they are skipped for simplicity
             // getPrototypeOf(target) { },
@@ -128,23 +152,15 @@ function createWrapFn(originalsToProxies, proxiesToOriginals, unwrapFn) {
 }
 
 /**
- * @param {any} obj
+ * @param {any} graph
  */
-function membrane(obj) {
-    const originalProxies = new WeakMap();
-    const originalTargets = new WeakMap();
-    const outerProxies = new WeakMap();
+function membrane(graph) {
+    const originalsToProxies = new WeakMap();
+    const proxiesToOriginals = new WeakMap();
 
-    const wrap = createWrapFn(originalProxies, originalTargets, unwrap);
-    const wrapOuter = createWrapFn(outerProxies, originalProxies, wrap)
+    const wrap = createWrapFn(originalsToProxies, proxiesToOriginals);
 
-    function unwrap(proxy) {
-        return originalTargets.has(proxy)
-            ? originalTargets.get(proxy)
-            : wrapOuter(proxy);
-    }
-
-    return wrap(obj);
+    return wrap(graph);
 }
 
 exports.membrane = membrane;

--- a/index.spec.js
+++ b/index.spec.js
@@ -2,153 +2,152 @@ const { membrane } = require(".");
 
 console.log('STARTED');
 
-const privateSymbol = Symbol('private'); // Symbol.private();
-const value = {};
-const Left = {
-    base: {
-        [privateSymbol]: value
-    },
-    value,
-    field: privateSymbol,
-    /**
-     * @param {symbol} key
-     * @param {object} val
-     */
-    assignment(key, val) {
-        Left.base[key] = val;
-    },
-    /**
-     * @param {symbol} key
-     * @param {object} val
-     */
-    assertion(key, val) {
-        console.assert(Left.base[key] === val);
-    },
-    /**
-     * @param {(fT: symbol, vT: object) => void} cb
-     */
-    callFunctionFromRight(cb) {
-        cb(Left.field, Left.value);
-    }
-};
-const Right = membrane(Left);
+function setup() {
+    const leftPriv = Symbol('left private'); // Symbol.private();
+    const leftValue = {};
+    const Left = {
+        base: {
+            [leftPriv]: leftValue
+        },
+        value: leftValue,
+        field: leftPriv,
+    };
 
-const { base: bT, field: fT, value: vT } = Left;
-const { base: bP, field: fP, value: vP } = Right;
-console.log('------------------------------------------');
-console.log('LEFT and RIGHT belongs to one scope')
+
+    const rightPriv = Symbol('right private'); // Symbol.private();
+    const rightValue = {};
+    const Right = {
+        base: {
+            [rightPriv]: rightValue
+        },
+        value: rightValue,
+        field: rightPriv,
+    };
+
+    // graph lives on the "left side"
+    const graph = {
+        Left,
+    };
+    // wrappedGraph lives on the "right side"
+    const wrappedGraph = membrane(graph);
+    wrappedGraph.Right = Right;
+
+    const wrappedLeftSide = wrappedGraph.Left;
+    const wrappedRightSide = graph.Right;
+    return {
+        Left,
+        Right,
+        wrappedLeftSide,
+        wrappedRightSide,
+    };
+}
+
 console.log('------------------------------------------');
 
 console.log('# set on left side of membrane');
 console.log('## set using left side field name');
-console.log('### bT[fT] = vT;')
-Left.assignment(fT, vT);
-Right.callFunctionFromRight((fT, vT) => {
-    console.assert(bP[fP] === vP);
-});
 
-console.log('### bT[fT] = vP;')
-Left.assignment(fT, vP);
-Right.callFunctionFromRight((fT, vT) => {
-    console.assert(bP[fP] === vT);
-});
+{
+    const {
+        Left,
+        Right,
+        wrappedLeftSide,
+        wrappedRightSide,
+    } = setup();
+    console.log('### bT[fT] = vT;')
+    Left.base[Left.field] = Left.value;
+    console.assert(wrappedLeftSide.base[wrappedLeftSide.field] === wrappedLeftSide.value);
+}
+
+{
+    const {
+        Left,
+        Right,
+        wrappedLeftSide,
+        wrappedRightSide,
+    } = setup();
+    console.log('### bT[fT] = vP;')
+    Left.base[Left.field] = wrappedRightSide.value;
+    console.assert(wrappedLeftSide.base[wrappedLeftSide.field] === Right.value);
+}
 
 console.log('## set using right side field name');
-console.log('### bT[fP] = vT;')
-Left.assignment(fP, vT);
-Right.callFunctionFromRight((fT, vT) => {
-    console.assert(bP[fT] === vP);
-});
 
-console.log('### bT[fP] = vP;')
-Left.assignment(fP, vP);
-Right.callFunctionFromRight((fT, vT) => {
-    console.assert(bP[fT] === vT);
-});
+{
+    const {
+        Left,
+        Right,
+        wrappedLeftSide,
+        wrappedRightSide,
+    } = setup();
+    console.log('### bT[fP] = vT;')
+    Left.base[wrappedRightSide.field] = Left.value;
+    console.assert(wrappedLeftSide.base[Right.field] === wrappedLeftSide.value);
+}
+
+{
+    const {
+        Left,
+        Right,
+        wrappedLeftSide,
+        wrappedRightSide,
+    } = setup();
+    console.log('### bT[fP] = vP;')
+    Left.base[wrappedRightSide.field] = wrappedRightSide.value;
+    console.assert(wrappedLeftSide.base[Right.field] === Right.value);
+}
 
 console.log('# set on right side of membrane');
 console.log('## set using left side field name');
-console.log('### bP[fT] = vT;')
-Left.callFunctionFromRight((fT, vT) => {
-    bP[fT] = vT;
-});
-Right.assertion(fP, vP);
 
-console.log('### bP[fT] = vP;')
-Left.callFunctionFromRight((fT, vT) => {
-    bP[fT] = vP;
-});
-Right.assertion(fP, vT);
+{
+    const {
+        Left,
+        Right,
+        wrappedLeftSide,
+        wrappedRightSide,
+    } = setup();
+    console.log('### bP[fT] = vT;')
+    wrappedRightSide.base[Left.field] = Left.value;
+    console.assert(Right.base[wrappedLeftSide.field] === wrappedLeftSide.value);
+}
 
-console.log('## set using right side field name');
-console.log('### bP[fP] = vT;')
-Left.callFunctionFromRight((fT, vT) => {
-    bP[fP] = vT;
-});
-Right.assertion(fT, vP);
-
-console.log('### bP[fP] = vP;')
-Left.callFunctionFromRight((fT, vT) => {
-    bP[fP] = vP;
-});
-Right.assertion(fT, vT);
-
-console.log('------------------------------------------');
-console.log('LEFT and RIGHT belongs to different scopes');
-console.log('------------------------------------------');
-
-console.log('# set on left side of membrane');
-console.log('## set using left side field name');
-console.log('### bT[fT] = vT;')
-Right.assignment(fT, vT);
-Right.callFunctionFromRight((fT, vT) => {
-    console.assert(bP[fP] === vP);
-});
-
-console.log('### bT[fT] = vP;')
-Right.assignment(fT, vP);
-Right.callFunctionFromRight((fT, vT) => {
-    console.assert(bP[fP] === vT);
-});
+{
+    const {
+        Left,
+        Right,
+        wrappedLeftSide,
+        wrappedRightSide,
+    } = setup();
+    console.log('### bP[fT] = vP;')
+    wrappedRightSide.base[Left.field] = wrappedRightSide.value;
+    console.assert(Right.base[wrappedLeftSide.field] === Right.value);
+}
 
 console.log('## set using right side field name');
-console.log('### bT[fP] = vT;')
-Right.assignment(fP, vT);
-Right.callFunctionFromRight((fT, vT) => {
-    console.assert(bP[fT] === vP);
-});
 
-console.log('### bT[fP] = vP;')
-Right.assignment(fP, vP);
-Right.callFunctionFromRight((fT, vT) => {
-    console.assert(bP[fT] === vT);
-});
+{
+    const {
+        Left,
+        Right,
+        wrappedLeftSide,
+        wrappedRightSide,
+    } = setup();
+    console.log('### bP[fP] = vT;')
+    wrappedRightSide.base[wrappedRightSide.field] = Left.value;
+    console.assert(Right.base[Right.field] === wrappedLeftSide.value);
+}
 
-console.log('# set on right side of membrane');
-console.log('## set using left side field name');
-console.log('### bP[fT] = vT;')
-Right.callFunctionFromRight((fT, vT) => {
-    bP[fT] = vT;
-});
-Right.assertion(fP, vP);
-
-console.log('### bP[fT] = vP;')
-Right.callFunctionFromRight((fT, vT) => {
-    bP[fT] = vP;
-});
-Right.assertion(fP, vT);
-
-console.log('## set using right side field name');
-console.log('### bP[fP] = vT;')
-Right.callFunctionFromRight((fT, vT) => {
-    bP[fP] = vT;
-});
-Right.assertion(fT, vP);
-
-console.log('### bP[fP] = vP;')
-Right.callFunctionFromRight((fT, vT) => {
-    bP[fP] = vP;
-});
-Right.assertion(fT, vT);
+{
+    const {
+        Left,
+        Right,
+        wrappedLeftSide,
+        wrappedRightSide,
+    } = setup();
+    console.log('### bP[fP] = vP;')
+    wrappedRightSide.base[wrappedRightSide.field] = wrappedRightSide.value;
+    console.assert(Right.base[Right.field] === Right.value);
+}
 
 console.log('PASSED');


### PR DESCRIPTION
This properly sets up the left and right sides through the `graph` (and `wrappedGraph`) objects.

Note that this leaves "private symbols" undone, I'm using public symbols to assert that the invariants are held for public fields. The `index.spec.js` code should no longer need to change, only the membrane implementation.