### PR TITLE
Revamp test suite

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,8 +82,7 @@ function createWrapFn(originalsToProxies, proxiesToOriginals) {
         //       note that we don't use `original` here as proxy target
         //                     ↓↓↓↓↓↓↓↓↓↓↓↓↓↓
         // TODO
-        // const proxy = newProxy(privateHandler, {
-        const proxy = new Proxy(privateHandler, {
+        const proxy = newProxy(privateHandler, {
             apply(target, thisArg, argArray) {
                 thisArg = unwrap(thisArg);
                 for (let i = 0; i < argArray.length; i++) {

--- a/new-proxy.js
+++ b/new-proxy.js
@@ -3,37 +3,44 @@
  * @param {ProxyHandler} handler
  */
 function newProxy(obj, handler) {
+    /**
+     * @param {symbol} sym
+     */
+    function isPrivate(sym) {
+        return typeof sym === 'symbol' && !!sym.private;
+    }
+
     return new Proxy(obj, {
         ...handler,
         get(target, p, receiver) {
-            if (typeof p !== 'symbol' && handler.get) return handler.get(target, p, receiver);
+            if (!isPrivate(p) && handler.get) return handler.get(target, p, receiver);
 
             return Reflect.get(target, p, receiver);
         },
         getOwnPropertyDescriptor(target, p) {
-            if (typeof p !== 'symbol' && handler.getOwnPropertyDescriptor) return handler.getOwnPropertyDescriptor(target, p);
+            if (!isPrivate(p) && handler.getOwnPropertyDescriptor) return handler.getOwnPropertyDescriptor(target, p);
 
             return Reflect.getOwnPropertyDescriptor(target, p);
         },
         has(target, p) {
-            if (typeof p !== 'symbol' && handler.has) return handler.has(target, p);
+            if (!isPrivate(p) && handler.has) return handler.has(target, p);
 
             return Reflect.has(target, p);
 
         },
         set(target, p, value, receiver) {
-            if (typeof p !== 'symbol' && handler.set) return handler.set(target, p, value, receiver);
+            if (!isPrivate(p) && handler.set) return handler.set(target, p, value, receiver);
 
             return Reflect.set(target, p, value, receiver);
 
         },
         deleteProperty(target, p) {
-            if (typeof p !== 'symbol' && handler.deleteProperty) return handler.deleteProperty(target, p);
+            if (!isPrivate(p) && handler.deleteProperty) return handler.deleteProperty(target, p);
 
             return Reflect.deleteProperty(target, p);
         },
         defineProperty(target, p, attributes) {
-            if (typeof p !== 'symbol' && handler.defineProperty) return handler.defineProperty(target, p, attributes);
+            if (!isPrivate(p) && handler.defineProperty) return handler.defineProperty(target, p, attributes);
 
             return Reflect.defineProperty(target, p, attributes);
         },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node index.spec.js"
+    "test": "node tests/index.js"
   },
   "repository": {
     "type": "git",

--- a/tests/__helpers.js
+++ b/tests/__helpers.js
@@ -1,0 +1,233 @@
+const { membrane } = require('..');
+const assert = require('assert');
+require('./__polyfill');
+
+global.describe = function(name, cb) {
+    console.group(name);
+    cb();
+    console.groupEnd(name);
+}
+global.it = function(name, cb) {
+    try {
+        cb();
+        console.log('\x1b[32m', '\u2713', name, '\x1b[0m');
+    } catch (e) {
+        debugger;
+        console.log('\x1b[31m', '\u2718', name, '\x1b[0m');
+        console.group('');
+        console.log(e.stack);
+        console.groupEnd('');
+    }
+}
+
+function setup(leftField, rightField) {
+    const Left = {
+        base: {},
+        field: leftField,
+        value: { fromTheLeft: true },
+
+        get(obj) {
+            return obj[leftField];
+        },
+        set(obj, value) {
+            obj[leftField] = value;
+        },
+    };
+
+    const Right = {
+        base: {},
+        field: rightField,
+        value: { fromTheRight: true },
+
+        get(obj) {
+            return obj[rightField];
+        },
+        set(obj, value) {
+            obj[rightField] = value;
+        }
+    }
+
+    const graph = {};
+    const wrappedGraph = new membrane(graph);
+    graph.Left = Left;
+    wrappedGraph.Right = Right;
+
+    const wrappedLeftSide = wrappedGraph.Left;
+    const wrappedRightSide = graph.Right;
+
+    return {
+        Left,
+        Right,
+        wrappedLeftSide,
+        wrappedRightSide,
+    };
+}
+
+exports.stringFields = function() {
+    return setup('leftField', 'rightField');
+}
+
+exports.symbolFields = function() {
+    return setup(Symbol('leftField'), Symbol('rightField'));
+}
+
+exports.privateSymbolFields = function() {
+    return setup(Symbol.private('leftField'), Symbol.private('rightField'));
+}
+
+exports.preExposedPrivateSymbolFields = function() {
+    const membrane = setup(Symbol.private('leftField'), Symbol.private('rightField'));
+    // Expose the fields before the tests.
+    membrane.wrappedLeftSide.field;
+    membrane.wrappedRightSide.field;
+    return membrane;
+}
+
+exports.suite = function(setup, set, get) {
+    it('bT[fT] = vT;', () => {
+        const {
+            Left,
+            Right,
+            wrappedLeftSide,
+            wrappedRightSide,
+        } = setup();
+        set(Left, Left.base, Left.value);
+
+        const got = get(wrappedLeftSide, wrappedLeftSide.base);
+
+        // Test that it's wrapped.
+        assert.notStrictEqual(got, Left.value);
+        // Test that it's the wrapped left value.
+        assert.strictEqual(got.fromTheLeft, true);
+        // Sanity check.
+        assert.strictEqual(get(Left, Left.base), Left.value);
+    });
+
+    it('bT[fT] = vP;', () => {
+        const {
+            Left,
+            Right,
+            wrappedLeftSide,
+            wrappedRightSide,
+        } = setup();
+        set(Left, Left.base, wrappedRightSide.value);
+
+        const got = get(wrappedLeftSide, wrappedLeftSide.base);
+
+        // Test that it's unwrapped.
+        assert.strictEqual(got, Right.value);
+        // Test that it was the wrapped right value.
+        assert.strictEqual(wrappedRightSide.value.fromTheRight, true);
+        // Sanity check.
+        assert.strictEqual(get(Left, Left.base), wrappedRightSide.value);
+    });
+
+    it('bT[fP] = vT;', () => {
+        const {
+            Left,
+            Right,
+            wrappedLeftSide,
+            wrappedRightSide,
+        } = setup();
+        set(wrappedRightSide, Left.base, Left.value);
+
+        const got = get(Right, wrappedLeftSide.base);
+
+        // Test that it's wrapped.
+        assert.notStrictEqual(got, Left.value);
+        // Test that it's the wrapped left value.
+        assert.strictEqual(got.fromTheLeft, true);
+        // Sanity check.
+        assert.strictEqual(get(wrappedRightSide, Left.base), Left.value);
+    });
+
+    it('bT[fP] = vP;', () => {
+        const {
+            Left,
+            Right,
+            wrappedLeftSide,
+            wrappedRightSide,
+        } = setup();
+        set(wrappedRightSide, Left.base, wrappedRightSide.value);
+
+        const got = get(Right, wrappedLeftSide.base);
+        // Test that it's unwrapped.
+        assert.strictEqual(got, Right.value);
+        // Test that it was the wrapped right value.
+        assert.strictEqual(wrappedRightSide.value.fromTheRight, true);
+        // Sanity check.
+        assert.strictEqual(get(wrappedRightSide, Left.base), wrappedRightSide.value);
+    });
+
+    it('bP[fT] = vT;', () => {
+        const {
+            Left,
+            Right,
+            wrappedLeftSide,
+            wrappedRightSide,
+        } = setup();
+        set(Left, wrappedRightSide.base, Left.value);
+
+        const got = get(wrappedLeftSide, Right.base);
+        // Test that it's wrapped.
+        assert.notStrictEqual(got, Left.value);
+        // Test that it's the wrapped left value.
+        assert.strictEqual(got.fromTheLeft, true);
+        // Sanity check.
+        assert.strictEqual(get(Left, wrappedRightSide.base), Left.value);
+    });
+
+    it('bP[fT] = vP;', () => {
+        const {
+            Left,
+            Right,
+            wrappedLeftSide,
+            wrappedRightSide,
+        } = setup();
+        set(Left, wrappedRightSide.base, wrappedRightSide.value);
+
+        const got = get(wrappedLeftSide, Right.base);
+        // Test that it's unwrapped.
+        assert.strictEqual(got, Right.value);
+        // Test that it was the wrapped right value.
+        assert.strictEqual(wrappedRightSide.value.fromTheRight, true);
+        // Sanity check.
+        assert.strictEqual(get(Left, wrappedRightSide.base), wrappedRightSide.value);
+    });
+
+    it('bP[fP] = vT;', () => {
+        const {
+            Left,
+            Right,
+            wrappedLeftSide,
+            wrappedRightSide,
+        } = setup();
+        set(wrappedRightSide, wrappedRightSide.base, Left.value);
+
+        const got = get(Right, Right.base);
+        // Test that it's wrapped.
+        assert.notStrictEqual(got, Left.value);
+        // Test that it's the wrapped left value.
+        assert.strictEqual(got.fromTheLeft, true);
+        // Sanity check.
+        assert.strictEqual(get(wrappedRightSide, wrappedRightSide.base), Left.value);
+    });
+
+    it('bP[fP] = vP;', () => {
+        const {
+            Left,
+            Right,
+            wrappedLeftSide,
+            wrappedRightSide,
+        } = setup();
+        set(wrappedRightSide, wrappedRightSide.base, wrappedRightSide.value);
+
+        const got = get(Right, Right.base);
+        // Test that it's unwrapped.
+        assert.strictEqual(got, Right.value);
+        // Test that it was the wrapped right value.
+        assert.strictEqual(wrappedRightSide.value.fromTheRight, true);
+        // Sanity check.
+        assert.strictEqual(get(wrappedRightSide, wrappedRightSide.base), wrappedRightSide.value);
+    });
+};

--- a/tests/__polyfill.js
+++ b/tests/__polyfill.js
@@ -1,0 +1,13 @@
+const privates = new Set();
+Symbol.private = function(desc) {
+    const sym = Symbol(desc);
+    privates.add(sym);
+    return sym;
+};
+Object.defineProperty(Symbol.prototype, 'private', {
+    configurable: true,
+    get() {
+        return privates.has(this.valueOf());
+    },
+});
+

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,49 @@
+const helpers = require('./__helpers');
+
+describe('Membranes', () => {
+    describe('Closure based access', () => {
+        const set = (Side, base, value) => {
+            Side.set(base, value);
+        };
+        const get = (Side, base) => {
+            return Side.get(base);
+        };
+
+        describe('string fields', () => {
+            helpers.suite(helpers.stringFields, set, get);
+        });
+
+        describe('public symbol fields', () => {
+            helpers.suite(helpers.symbolFields, set, get);
+        });
+
+        describe('private symbol fields', () => {
+            helpers.suite(helpers.privateSymbolFields, set, get);
+        });
+    });
+
+    describe('Reified key based access', () => {
+        const set = (Side, base, value) => {
+            base[Side.field] = value;
+        };
+        const get = (Side, base) => {
+            return base[Side.field];
+        };
+
+        describe('string fields', () => {
+            helpers.suite(helpers.stringFields, set, get);
+        });
+
+        describe('public symbol fields', () => {
+            helpers.suite(helpers.symbolFields, set, get);
+        });
+
+        describe('private symbol fields', () => {
+            helpers.suite(helpers.privateSymbolFields, set, get);
+        });
+
+        describe('private symbol fields (pre exposed)', () => {
+            helpers.suite(helpers.preExposedPrivateSymbolFields, set, get);
+        });
+    });
+});


### PR DESCRIPTION
This'll now test string fields, public symbols, and private symbols
(both exposed before the set operation and after).

Also, it tests closure based access, which is how the syntax-only
private fields operate.